### PR TITLE
Agrego test de integracion con healthcheck db en yml

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "NODE_ENV=test jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/axios": "^4.0.0",

--- a/backend/test/lotes/lotes.e2e-spec.ts
+++ b/backend/test/lotes/lotes.e2e-spec.ts
@@ -1,0 +1,90 @@
+import { INestApplication } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { AppModule } from "src/app.module";
+import { Lote } from "src/entities/lote.entity";
+import { Sucursal } from "src/entities/sucursal.entity";
+import { generarLoteEntidad } from "../utils/lote-fixture";
+import { generarSucursalEntidad } from "../utils/sucursal-fixture";
+import { DataSource } from "typeorm";
+import request from 'supertest';
+import { Producto } from "src/entities/producto.entity";
+import { generarProductoEntidad } from "../utils/producto-fixture";
+import { ErrorCodes } from "common/constants/error-codes";
+
+jest.setTimeout(20000);
+
+describe('LotesController (e2e)', () => {
+    let app: INestApplication;
+    let dataSource: DataSource;
+
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+
+        app.useLogger(false);
+
+        await app.init();
+
+        dataSource = moduleFixture.get(DataSource);
+    });
+
+    afterAll(async () => {
+        if (app) await app.close();
+    });
+
+    it('debería crear un lote correctamente', async () => {
+        const productoRepo = dataSource.getRepository(Producto);
+        const sucursalRepo = dataSource.getRepository(Sucursal);
+        const loteRepo = dataSource.getRepository(Lote);
+
+        const producto = await productoRepo.save(generarProductoEntidad());
+        const sucursal = await sucursalRepo.save(generarSucursalEntidad());
+
+        const lote = generarLoteEntidad();
+
+        const response = await request(app.getHttpServer())
+            .post('/lote')
+            .send({
+                cantidad: lote.cantidad,
+                fecha_vencimiento: lote.fecha_vencimiento.toISOString(),
+                id_producto: producto.id_producto,
+                id_sucursal: sucursal.id_sucursal
+            })
+            .expect(200);
+
+        const loteCreado = response.body;
+
+        const loteEncontrado = await loteRepo.findOne({
+            where: { id_lote: loteCreado.data.id_lote },
+            relations: ['producto', 'sucursal'],
+        });
+
+        expect(loteEncontrado).toBeDefined();
+        expect(loteCreado.success).toBe(true);
+        expect(loteCreado.data.producto.id_producto).toBe(producto.id_producto);
+        expect(loteCreado.data.sucursal.id_sucursal).toBe(sucursal.id_sucursal);
+    });
+
+    it('no debería crear un lote si falta id_producto', async () => {
+        const sucursalRepo = dataSource.getRepository(Sucursal);
+        const sucursal = await sucursalRepo.save(generarSucursalEntidad());
+        const lote = generarLoteEntidad();
+
+        const response = await request(app.getHttpServer())
+            .post('/lote')
+            .send({
+                cantidad: lote.cantidad,
+                fecha_vencimiento: lote.fecha_vencimiento.toISOString(),
+                id_producto: 455,
+                id_sucursal: sucursal.id_sucursal
+            })
+            .expect(200);
+
+        expect(response.body.success).toBe(false);
+        expect(response.body.message).toBeDefined();
+        expect(response.body.error.code).toBe(ErrorCodes.NOT_FOUND);
+    });
+});

--- a/backend/test/productos/productos.e2e-spec.ts
+++ b/backend/test/productos/productos.e2e-spec.ts
@@ -1,0 +1,45 @@
+import { INestApplication } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import request from 'supertest';
+import { AppModule } from "src/app.module";
+import { Producto } from "src/entities/producto.entity";
+import { generarProductoEntidad } from "../utils/producto-fixture";
+import { DataSource } from "typeorm";
+
+jest.setTimeout(20000);
+
+describe('ProductosController (e2e)', () => {
+    let app: INestApplication;
+    let dataSource: DataSource;
+
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        await app.init();
+
+        dataSource = moduleFixture.get(DataSource);
+    });
+
+    afterAll(async () => {
+        if (app) await app.close();
+    });
+
+    it('debería crear un producto correctamente', async () => {
+        const productoRepo = dataSource.getRepository(Producto);
+        const producto = generarProductoEntidad();
+
+        const response = await request(app.getHttpServer())
+            .post('/producto')
+            .send(producto)
+            .expect(201);
+
+        const productoCreado = response.body;
+
+        const productoEncontrado = await productoRepo.findOneBy({ id_producto: productoCreado.id_producto });
+        expect(productoEncontrado).toBeDefined();
+        expect(productoEncontrado?.nombre).toBe(producto.nombre);
+    });
+});

--- a/backend/test/sucursales/sucursales.e2e-spec.ts
+++ b/backend/test/sucursales/sucursales.e2e-spec.ts
@@ -1,0 +1,45 @@
+import { INestApplication } from "@nestjs/common";
+import { TestingModule, Test } from "@nestjs/testing";
+import request from 'supertest'
+import { AppModule } from "src/app.module";
+import { Sucursal } from "src/entities/sucursal.entity";
+import { generarSucursalEntidad } from "../utils/sucursal-fixture";
+import { DataSource } from "typeorm";
+
+jest.setTimeout(20000);
+
+describe('SucursalController (e2e)', () => {
+    let app: INestApplication;
+    let dataSource: DataSource;
+
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        await app.init();
+
+        dataSource = moduleFixture.get(DataSource);
+    });
+
+    afterAll(async () => {
+        if (app) await app.close();
+    });
+
+    it('debería crear una sucursal correctamente', async () => {
+        const sucursalRepo = dataSource.getRepository(Sucursal);
+        const sucursal = generarSucursalEntidad();
+
+        const response = await request(app.getHttpServer())
+            .post('/sucursal')
+            .send(sucursal)
+            .expect(201);
+
+        const sucursalCreada = response.body;
+
+        const sucursalEncontrada = await sucursalRepo.findOneBy({ id_sucursal: sucursalCreada.id_sucursal });
+        expect(sucursalEncontrada).toBeDefined();
+        expect(sucursalEncontrada?.direccion).toBe(sucursal.direccion);
+    });
+});

--- a/backend/test/utils/cliente-fixture.ts
+++ b/backend/test/utils/cliente-fixture.ts
@@ -1,0 +1,14 @@
+import { faker } from "@faker-js/faker/.";
+import { Cliente } from "src/entities/cliente.entity";
+
+export function generarClienteEntidad(
+    overrides?: Partial<Cliente>
+): Cliente {
+    const cliente = new Cliente();
+    cliente.nombre = faker.person.fullName();
+    cliente.dni = faker.string.numeric(8);
+    cliente.puntos_fidelizacion = faker.number.int({ min: 0, max: 100 });
+    cliente.ventas = [{ id_venta: Math.floor(Math.random() * 100) + 1 } as any];
+
+    return Object.assign(cliente, overrides);
+}

--- a/backend/test/utils/lote-fixture.ts
+++ b/backend/test/utils/lote-fixture.ts
@@ -1,0 +1,14 @@
+import { Lote } from "src/entities/lote.entity";
+
+export function generarLoteEntidad(
+    overrides?: Partial<Lote>
+): Lote {
+    const lote = new Lote();
+    lote.fecha_vencimiento = new Date(
+        Date.now() + Math.floor(Math.random() * 1000000000)
+    );
+    lote.cantidad = Math.floor(Math.random() * 100) + 1;
+    lote.proveedor = { id_proveedor: Math.floor(Math.random() * 100) + 1 } as any;
+
+    return Object.assign(lote, overrides);
+}

--- a/backend/test/utils/producto-fixture.ts
+++ b/backend/test/utils/producto-fixture.ts
@@ -1,0 +1,18 @@
+import { faker } from "@faker-js/faker/.";
+import { Producto } from "src/entities/producto.entity";
+import { CategoriaProducto } from "src/enums/categoria-producto.enum";
+import { TipoProducto } from "src/enums/tipo-producto.enum";
+
+export function generarProductoEntidad(
+    overrides?: Partial<Producto>
+): Producto {
+    const producto = new Producto();
+    producto.codigo_nacional = faker.string.alphanumeric(10).toUpperCase();
+    producto.nombre = faker.commerce.productName();
+    producto.categoria = overrides?.categoria ?? CategoriaProducto.MEDICAMENTO;
+    producto.tipo = overrides?.tipo ?? TipoProducto.VENTA_LIBRE;
+    producto.umbral_stock = faker.number.int({ min: 0, max: 100 });
+    producto.precio_unitario = faker.number.float({ min: 10, max: 20000, fractionDigits: 2 });
+
+    return Object.assign(producto, overrides);
+}

--- a/backend/test/utils/sucursal-fixture.ts
+++ b/backend/test/utils/sucursal-fixture.ts
@@ -1,0 +1,16 @@
+import { faker } from "@faker-js/faker/.";
+import { Sucursal } from "src/entities/sucursal.entity";
+
+export function generarSucursalEntidad(
+    overrides?: Partial<Sucursal>
+): Sucursal {
+    const sucursal = new Sucursal();
+    sucursal.direccion = faker.location.streetAddress();
+    sucursal.telefono = faker.phone.number();
+    sucursal.dias_previos_aviso = faker.number.int({ min: 1, max: 30 });
+    sucursal.usuarios = [];
+    sucursal.lotes = [];
+    sucursal.ventas = [];
+
+    return Object.assign(sucursal, overrides);
+}

--- a/backend/test/utils/venta-fixture.ts
+++ b/backend/test/utils/venta-fixture.ts
@@ -1,0 +1,20 @@
+import { faker } from "@faker-js/faker/.";
+import { Venta } from "src/entities/venta.entity";
+
+export function generarVentaEntidad(
+    overrides?: Partial<Venta>
+): Venta {
+    const venta = new Venta();    
+    venta.fecha = faker.date.recent();//new Date();
+    venta.subtotal = faker.number.float({ min: 10, max: 20000, multipleOf: 0.02 })
+    venta.puntos_cliente_inicial = 0;
+    venta.descuento_porcentaje = 0;
+    venta.total_final = venta.subtotal;
+    venta.puntos_generados = 10;
+    venta.sucursal = { id_sucursal: Math.floor(Math.random() * 100) + 1 } as any;
+    venta.cliente = { id_cliente: Math.floor(Math.random() * 100) + 1 } as any;
+    venta.usuario = { id_usuario: Math.floor(Math.random() * 100) + 1 } as any;
+    venta.detalles = [];
+    
+    return Object.assign(venta, overrides);
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,12 @@ services:
       - ./initdb/:/docker-entrypoint-initdb.d  # <- Carpeta local mapeada
     networks:
       - app-network 
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   backend:   # Servicio para NestJS
     container_name: backend-farmacia
     build: ./backend  # Ruta a tu Dockerfile del backend
@@ -56,9 +62,10 @@ services:
     environment:
       NODE_ENV: test
     depends_on:
-      - mysql-farmacia
+      mysql-farmacia:
+        condition: service_healthy
     networks:
-      - app-network 
+      - app-network
 
 
 


### PR DESCRIPTION
- Agrego tests de integración para `sucursales`, `productos` y la creación de `lotes` vinculados, utilizando `fixtures` para los datos.

- Agrego un `healthcheck` en el servicio `mysql-farmacia`, utilizado por los tests, para asegurar que la base de datos esté completamente inicializada antes de ejecutar las pruebas. 
(Esto soluciona el problema de ejecución prematura: `depends_on` por sí solo espera que el contenedor inicie, pero no que esté listo para aceptar conexiones.)
